### PR TITLE
feat : .dockerignore 파일 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist


### PR DESCRIPTION
node_modules 에서 충돌이 발생하여 클라우드 서버 내 빌드 과정에서 실패함.
따라서 node_modules 폴더 COPY 대상에서 제외함.